### PR TITLE
This is a fix for sqlite3

### DIFF
--- a/db/migrate/013_recreate_views.rb
+++ b/db/migrate/013_recreate_views.rb
@@ -1,0 +1,14 @@
+class RecreateViews < ActiveRecord::Migration
+  def self.up
+    drop_view :issue_tags
+    drop_view :wiki_page_tags
+    create_view :issue_tags, "select taggings.id as id, tags.name as tag, taggings.taggable_id as issue_id from taggings join tags on taggings.tag_id = tags.id where taggable_type = 'Issue'" 
+    create_view :wiki_page_tags, "select taggings.id as id, tags.name as tag, taggings.taggable_id as wiki_page_id from taggings join tags on taggings.tag_id = tags.id where taggable_type = 'WikiPage'" 
+  end
+
+  def self.down
+    # noop
+  end
+
+end
+


### PR DESCRIPTION
Hi, I was having errors when searching on my Redmine installation. In sqlite3, the column name was "taggings.id" instead of just "id" so I just added a migration to fix this. 
