### PR TITLE
Fix Issue tag update to support api updates

### DIFF
--- a/lib/tagging_plugin/tagging_hooks.rb
+++ b/lib/tagging_plugin/tagging_hooks.rb
@@ -130,11 +130,11 @@ module TaggingPlugin
 
       def controller_issues_edit_before_save(context={})
         return if Setting.plugin_redmine_tagging[:issues_inline] == "1"
-        return unless context[:params] && context[:params]['issue']
+        #Do not update tags if its not passed in params
+        return unless context[:params] && context[:params]['issue'] && !context[:params]['issue']['tags'].nil?
 
         issue = context[:issue]
         tags = context[:params]['issue']['tags'].to_s
-
         tags = TagsHelper.from_string(tags)
         issue.tags_to_update = tags
       end


### PR DESCRIPTION
Currently Issue api put call removes all tags if these are not passed in update params. This breaks the contract of the api because it is supposed to support partial issue updates and tags is not a required parameter. 
Put in a minor fix to update issue tags only if they are passed in params otherwise leave them untouched.