### PR TITLE
preserve original search scopes

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -99,27 +99,6 @@ ActionDispatch::Callbacks.to_prepare do
   require File.expand_path('../app/helpers/tagging_helper', __FILE__)
   ActionView::Base.send :include, TaggingHelper
 
-  unless Issue.searchable_options[:include] && Issue.searchable_options[:include].include?(:issue_tags)
-    Issue.searchable_options[:columns] << "#{IssueTag.table_name}.tag"
-
-    # For redmine < 3
-    Issue.searchable_options[:include] ||= []
-    Issue.searchable_options[:include] << :issue_tags
-
-    # For redmine > 3
-    Issue.searchable_options[:scope] = proc { Issue.includes(:issue_tags) }
-  end
-
-  unless WikiPage.searchable_options[:include] && WikiPage.searchable_options[:include].include?(:wiki_page_tags)
-    WikiPage.searchable_options[:columns] << "#{WikiPageTag.table_name}.tag"
-
-    # For redmine < 3
-    WikiPage.searchable_options[:include] ||= []
-    WikiPage.searchable_options[:include] << :wiki_page_tags
-
-    # For redmine > 3
-    WikiPage.searchable_options[:scope] = proc { WikiPage.includes(:wiki_page_tags) }
-  end
 end
 
 require_dependency 'tagging_plugin/tagging_hooks'

--- a/lib/redmine_tagging/patches/issue_patch.rb
+++ b/lib/redmine_tagging/patches/issue_patch.rb
@@ -18,6 +18,15 @@ module RedmineTagging::Patches::IssuePatch
     alias_method_chain :create_journal, :tags
     alias_method_chain :init_journal, :tags
     alias_method_chain :copy_from, :tags
+
+    searchable_options[:columns] << 'issue_tags.tag'
+
+    original_scope = searchable_options[:scope] || self
+    searchable_options[:scope] = ->(*_) {
+      (original_scope.respond_to?(:call) ?
+         original_scope.call(*_) :
+         original_scope).includes :issue_tags
+    }
   end
 
   def create_journal_with_tags

--- a/lib/tagging_plugin/tagging_patches.rb
+++ b/lib/tagging_plugin/tagging_patches.rb
@@ -34,6 +34,15 @@ module TaggingPlugin
         acts_as_taggable
 
         has_many :wiki_page_tags
+
+        searchable_options[:columns] << "wiki_page_tags.tag"
+
+        original_scope = searchable_options[:scope] || self
+        searchable_options[:scope] = ->(*_){
+          (original_scope.respond_to?(:call) ?
+             original_scope.call(*_) :
+             original_scope).includes :wiki_page_tags
+        }
       end
     end
 


### PR DESCRIPTION
We had some problems with the overriding of `searchable_options[:scope]` in init.rb. This patch fixes this by extending a previously existing scope.

To simplify things a bit I decided to drop compatibility with Redmine < 3.