### PR TITLE
fixes taggable issue with recent wiki controller changes

### DIFF
--- a/lib/redmine_tagging/patches/wiki_page_patch.rb
+++ b/lib/redmine_tagging/patches/wiki_page_patch.rb
@@ -6,11 +6,10 @@ module RedmineTagging::Patches::WikiPagePatch
   included do
     unloadable
 
-    attr_writer :tags_to_update
-
     has_many :wiki_page_tags
 
     acts_as_taggable
+    safe_attributes :tags
 
     before_save :update_tags
 
@@ -29,6 +28,12 @@ module RedmineTagging::Patches::WikiPagePatch
           original_scope
         ).includes :wiki_page_tags
       }
+    end
+  end
+
+  def tags=(new_tags)
+    if new_tags
+      @tags_to_update = TaggingPlugin::TagsHelper.from_string(new_tags)
     end
   end
 

--- a/lib/tagging_plugin/tagging_patches.rb
+++ b/lib/tagging_plugin/tagging_patches.rb
@@ -18,30 +18,6 @@ module TaggingPlugin
     end
   end
 
-  module WikiControllerPatch
-    def self.included(base) # :nodoc:
-      base.send(:include, InstanceMethods)
-
-      base.class_eval do
-        unloadable
-
-        alias_method_chain :update, :tags
-      end
-    end
-
-    module InstanceMethods
-      def update_with_tags
-        if params[:wiki_page]
-          if tags = params[:wiki_page][:tags]
-            tags = TagsHelper.from_string(tags)
-            @page.tags_to_update = tags
-          end
-        end
-        update_without_tags
-      end
-    end
-  end
 end
 
-WikiController.send(:include, TaggingPlugin::WikiControllerPatch) unless WikiController.included_modules.include? TaggingPlugin::WikiControllerPatch
 ProjectsHelper.send(:include, TaggingPlugin::ProjectsHelperPatch) unless ProjectsHelper.included_modules.include? TaggingPlugin::ProjectsHelperPatch


### PR DESCRIPTION
A recent fix in Redmine's WikiController (http://www.redmine.org/issues/31334) broke updating wiki pages with the tagging plugin installed.

This patch avoids the situation by moving the tag parsing into a safe_attribute setter in the WikiPage model, making it unnecesary to patch the WikiController at all.